### PR TITLE
chore: configure git lfs asset handling

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,75 @@
+# Git attributes configured for Codex compatibility and binary prevention.
+# Ensures binary assets are tracked via Git LFS and excluded from textual diffs.
+
+# Images
+*.png binary -diff
+*.jpg binary -diff
+*.jpeg binary -diff
+*.gif binary -diff
+*.webp binary -diff
+*.svg binary -diff
+*.ico binary -diff
+*.bmp binary -diff
+*.tif binary -diff
+*.tiff binary -diff
+
+# Fonts
+*.woff binary -diff
+*.woff2 binary -diff
+*.ttf binary -diff
+*.otf binary -diff
+*.eot binary -diff
+*.sfnt binary -diff
+*.fnt binary -diff
+
+# Audio / Video
+*.mp3 binary -diff
+*.wav binary -diff
+*.ogg binary -diff
+*.flac binary -diff
+*.aac binary -diff
+*.m4a binary -diff
+*.mp4 binary -diff
+*.mov binary -diff
+*.avi binary -diff
+*.webm binary -diff
+*.mkv binary -diff
+
+# Archives and other binary blobs
+*.zip binary -diff
+*.tar binary -diff
+*.gz binary -diff
+*.bz2 binary -diff
+*.7z binary -diff
+*.rar binary -diff
+*.dmg binary -diff
+*.iso binary -diff
+
+# Design files
+*.psd binary -diff
+*.ai binary -diff
+*.sketch binary -diff
+*.fig binary -diff
+*.xd binary -diff
+
+# Git LFS tracking for Codex compatibility
+*.png filter=lfs diff=lfs merge=lfs -text
+*.jpg filter=lfs diff=lfs merge=lfs -text
+*.jpeg filter=lfs diff=lfs merge=lfs -text
+*.gif filter=lfs diff=lfs merge=lfs -text
+*.webp filter=lfs diff=lfs merge=lfs -text
+*.ico filter=lfs diff=lfs merge=lfs -text
+*.woff filter=lfs diff=lfs merge=lfs -text
+*.woff2 filter=lfs diff=lfs merge=lfs -text
+*.ttf filter=lfs diff=lfs merge=lfs -text
+*.otf filter=lfs diff=lfs merge=lfs -text
+
+# Lock files should remain text for clean diffs
+package-lock.json text -diff
+pnpm-lock.yaml text -diff
+yarn.lock text -diff
+
+# Project specific: ensure public assets use LFS
+public/**/* filter=lfs diff=lfs merge=lfs -text
+
+# Reminder: run `git lfs install` locally before committing large assets.

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,23 +1,23 @@
 # Git attributes configured for Codex compatibility and binary prevention.
 # Ensures binary assets are tracked via Git LFS and excluded from textual diffs.
 
-# Images
-*.png binary -diff
-*.jpg binary -diff
-*.jpeg binary -diff
-*.gif binary -diff
-*.webp binary -diff
-*.svg binary -diff
-*.ico binary -diff
+# Images stored via Git LFS for Codex compatibility
+*.png binary filter=lfs diff=lfs merge=lfs -text
+*.jpg binary filter=lfs diff=lfs merge=lfs -text
+*.jpeg binary filter=lfs diff=lfs merge=lfs -text
+*.gif binary filter=lfs diff=lfs merge=lfs -text
+*.webp binary filter=lfs diff=lfs merge=lfs -text
+*.ico binary filter=lfs diff=lfs merge=lfs -text
 *.bmp binary -diff
 *.tif binary -diff
 *.tiff binary -diff
+*.svg binary -diff
 
-# Fonts
-*.woff binary -diff
-*.woff2 binary -diff
-*.ttf binary -diff
-*.otf binary -diff
+# Fonts stored via Git LFS for Codex compatibility
+*.woff binary filter=lfs diff=lfs merge=lfs -text
+*.woff2 binary filter=lfs diff=lfs merge=lfs -text
+*.ttf binary filter=lfs diff=lfs merge=lfs -text
+*.otf binary filter=lfs diff=lfs merge=lfs -text
 *.eot binary -diff
 *.sfnt binary -diff
 *.fnt binary -diff
@@ -52,24 +52,21 @@
 *.fig binary -diff
 *.xd binary -diff
 
-# Git LFS tracking for Codex compatibility
-*.png filter=lfs diff=lfs merge=lfs -text
-*.jpg filter=lfs diff=lfs merge=lfs -text
-*.jpeg filter=lfs diff=lfs merge=lfs -text
-*.gif filter=lfs diff=lfs merge=lfs -text
-*.webp filter=lfs diff=lfs merge=lfs -text
-*.ico filter=lfs diff=lfs merge=lfs -text
-*.woff filter=lfs diff=lfs merge=lfs -text
-*.woff2 filter=lfs diff=lfs merge=lfs -text
-*.ttf filter=lfs diff=lfs merge=lfs -text
-*.otf filter=lfs diff=lfs merge=lfs -text
+# Public directory overrides to avoid wildcard LFS
+public/**/*.png binary filter=lfs diff=lfs merge=lfs -text
+public/**/*.jpg binary filter=lfs diff=lfs merge=lfs -text
+public/**/*.jpeg binary filter=lfs diff=lfs merge=lfs -text
+public/**/*.gif binary filter=lfs diff=lfs merge=lfs -text
+public/**/*.webp binary filter=lfs diff=lfs merge=lfs -text
+public/**/*.ico binary filter=lfs diff=lfs merge=lfs -text
+public/**/*.woff binary filter=lfs diff=lfs merge=lfs -text
+public/**/*.woff2 binary filter=lfs diff=lfs merge=lfs -text
+public/**/*.ttf binary filter=lfs diff=lfs merge=lfs -text
+public/**/*.otf binary filter=lfs diff=lfs merge=lfs -text
 
 # Lock files should remain text for clean diffs
 package-lock.json text -diff
 pnpm-lock.yaml text -diff
 yarn.lock text -diff
-
-# Project specific: ensure public assets use LFS
-public/**/* filter=lfs diff=lfs merge=lfs -text
 
 # Reminder: run `git lfs install` locally before committing large assets.

--- a/.gitignore
+++ b/.gitignore
@@ -36,7 +36,3 @@ Icon?
 public/uploads/
 public/videos/
 
-# Misc lock files
-package-lock.json
-pnpm-lock.yaml
-yarn.lock

--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,12 @@
 # Dependencies
 node_modules/
+.pnp/
+.pnp.js
 
 # Build outputs
 .next/
 out/
+dist/
 
 # Logs
 npm-debug.log*
@@ -18,12 +21,22 @@ yarn-error.log*
 .env.test.local
 .env.production.local
 
+# OS-specific
+.DS_Store
+Thumbs.db
+Icon?
+*.swp
+
 # IDEs and editors
 .vscode/
 .idea/
-.DS_Store
+*.iml
 
-# Misc
+# Binary asset uploads
+public/uploads/
+public/videos/
+
+# Misc lock files
 package-lock.json
 pnpm-lock.yaml
 yarn.lock

--- a/.gitlfsconfig
+++ b/.gitlfsconfig
@@ -1,0 +1,16 @@
+# Git LFS configuration for StockFlow
+[lfs]
+  url = https://github.com
+  locksverify = true
+
+# Developers should run `git lfs install` once per machine before working with large assets.
+
+[filter "lfs"]
+  required = true
+  clean = git lfs clean -- %f
+  smudge = git lfs smudge -- %f
+  process = git lfs filter-process
+
+[lfs "public"]
+  include = public/**
+  exclude =

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,11 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 ### Added
 - Configured Git LFS support and binary prevention guidelines for Codex contributors.
+- Documented Codex verification checklist and binary prevention reminders for future tasks.
 
 ### Changed
 - Expanded `.gitignore` entries to cover Next.js builds, OS files, and asset upload directories.
+- Consolidated `.gitattributes` LFS patterns and restored lock files to version control for reliable dependency auditing.
 
 ## [0.2.0] - 2025-10-02
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+### Added
+- Configured Git LFS support and binary prevention guidelines for Codex contributors.
+
+### Changed
+- Expanded `.gitignore` entries to cover Next.js builds, OS files, and asset upload directories.
+
 ## [0.2.0] - 2025-10-02
 ### Changed
 - **BREAKING**: Migrated backend architecture from Google Sheets to Supabase PostgreSQL for improved performance, querying capabilities, and multi-tenant support with RLS

--- a/docs/CODEX_GUIDELINES.md
+++ b/docs/CODEX_GUIDELINES.md
@@ -9,6 +9,19 @@ These guidelines help AI contributors prepare StockFlow for binary-safe workflow
 - Lock files remain tracked as plain text to maintain reliable diffing and dependency auditing.
 - Verify attributes with `git check-attr -a <file>` before committing new assets.
 
+## Verification Checklist
+```bash
+# Confirm tracked patterns registered with Git LFS
+git lfs track
+
+# Inspect attributes for a specific asset prior to committing
+git check-attr -a public/logo.png
+# Expected output includes: filter: lfs, diff: lfs, merge: lfs, binary
+
+# Review the list of files currently tracked by LFS
+git lfs ls-files
+```
+
 ## Placeholder Asset Strategy
 - When mock visuals are required, prefer hosted placeholders over storing local binaries.
 - Use [`https://placehold.co/{width}x{height}`](https://placehold.co) for preview URLs during development.
@@ -35,3 +48,15 @@ These guidelines help AI contributors prepare StockFlow for binary-safe workflow
 - Confirm tracked patterns via `git lfs track` and commit updates to `.gitattributes` when new binary types arise.
 - Avoid storing secrets or configuration files in LFS—it's dedicated to large binaries only.
 - When cloning or pulling, ensure collaborators run `git lfs pull` to download the actual binary content.
+
+## ⚠️ Critical: For All Future Codex Tasks
+
+**Never include:**
+- ❌ Creating `favicon.ico`, `logo.png`, or other binary design assets.
+- ❌ Downloading or committing font files manually.
+- ❌ Generating image, audio, or video binaries inside the repository.
+
+**Always include when assets are required:**
+- ✅ Placeholder URLs such as `https://placehold.co/{width}x{height}`.
+- ✅ Icons from `lucide-react` components, e.g. `<Icon className="h-4 w-4" />`.
+- ✅ Fonts imported via `next/font/google` (or existing shared loaders).

--- a/docs/CODEX_GUIDELINES.md
+++ b/docs/CODEX_GUIDELINES.md
@@ -1,0 +1,37 @@
+# Codex Contribution Guidelines
+
+These guidelines help AI contributors prepare StockFlow for binary-safe workflows and consistent asset handling.
+
+## Binary Prevention Rules
+- Use Git LFS for all binary assets including images, fonts, audio, and video files.
+- Never commit raw binaries directly; only LFS pointers should reach the repository.
+- Treat archives (zip, tar, gz, bz2, 7z) and design sources (psd, fig, sketch, xd, ai) as binary with `-diff` attributes.
+- Lock files remain tracked as plain text to maintain reliable diffing and dependency auditing.
+- Verify attributes with `git check-attr -a <file>` before committing new assets.
+
+## Placeholder Asset Strategy
+- When mock visuals are required, prefer hosted placeholders over storing local binaries.
+- Use [`https://placehold.co/{width}x{height}`](https://placehold.co) for preview URLs during development.
+- Document placeholder usage inside component stories or fixtures for future replacement.
+
+## Icon Strategy
+- StockFlow standardizes on [`lucide-react`](https://github.com/lucide-icons/lucide) for iconography.
+- Import icons as components rather than bundling SVG assets manually.
+- Avoid duplicating icon SVGs inside the repository; reference Lucide exports instead.
+
+## Font Strategy
+- Load fonts with `next/font/google` or the appropriate built-in Next.js font loader.
+- Do not commit raw font binaries. If a custom font is required, coordinate to host it via LFS or an external CDN.
+- Keep font usage centralized to maintain consistent typography across the application.
+
+## Git Apply Recovery Workflow
+1. Run `git status` to inspect partial patches or conflicts introduced by `git apply`.
+2. Use `git apply --reject --whitespace=fix <patch>` if the initial apply fails to gather `.rej` files for manual resolution.
+3. Resolve conflicts by editing affected files and removing any `.rej` artifacts once reconciled.
+4. Execute `git add -A` followed by `git diff --staged` to confirm a clean, intentional patch before committing.
+
+## Git LFS Usage Notes
+- Initialize LFS locally with `git lfs install` before working with tracked assets.
+- Confirm tracked patterns via `git lfs track` and commit updates to `.gitattributes` when new binary types arise.
+- Avoid storing secrets or configuration files in LFS—it's dedicated to large binaries only.
+- When cloning or pulling, ensure collaborators run `git lfs pull` to download the actual binary content.

--- a/docs/FILE_INVENTORY.md
+++ b/docs/FILE_INVENTORY.md
@@ -6,10 +6,13 @@ Update this file whenever you add, remove, or significantly modify any file.
 | --- | --- | --- |
 | `AGENT.md` | Guidance for AI contributors working on StockFlow. | Initial creation of agent workflow instructions. |
 | `README.md` | High-level project overview and quick start information. | Replaced placeholder with full project summary. |
-| `.gitignore` | Defines files and folders excluded from version control. | Added Node/Next.js defaults and environment exclusions. |
+| `.gitignore` | Defines files and folders excluded from version control. | Expanded ignores for builds, OS artifacts, and upload directories. |
+| `.gitattributes` | Configures binary detection and Git LFS tracking rules. | Added Codex-ready binary exclusions and LFS filters. |
+| `.gitlfsconfig` | Repository-specific Git LFS configuration. | Documented default LFS settings for public assets. |
 | `.env.example` | Lists required environment variables with placeholders. | Documented required secrets for local setup. |
 | `CHANGELOG.md` | Records notable changes across releases. | Logged version 0.1.0 initial setup. |
 | `docs/CONTEXT.md` | Captures business context, rules, and decisions. | Documented initial business context. |
 | `docs/ARCHITECTURE.md` | Describes technical stack and architecture decisions. | Documented initial architecture. |
-| `docs/FILE_INVENTORY.md` | Tracks project files, their purposes, and changes. | Populated inventory with initial documentation files. |
+| `docs/FILE_INVENTORY.md` | Tracks project files, their purposes, and changes. | Added Codex binary-prevention assets to inventory. |
 | `docs/SETUP.md` | Provides environment, tooling, and deployment instructions. | Documented setup steps for local and Vercel environments. |
+| `docs/CODEX_GUIDELINES.md` | Binary prevention and Git LFS guidance for AI contributors. | Created guidelines for Codex-safe asset handling. |

--- a/docs/FILE_INVENTORY.md
+++ b/docs/FILE_INVENTORY.md
@@ -6,8 +6,8 @@ Update this file whenever you add, remove, or significantly modify any file.
 | --- | --- | --- |
 | `AGENT.md` | Guidance for AI contributors working on StockFlow. | Initial creation of agent workflow instructions. |
 | `README.md` | High-level project overview and quick start information. | Replaced placeholder with full project summary. |
-| `.gitignore` | Defines files and folders excluded from version control. | Expanded ignores for builds, OS artifacts, and upload directories. |
-| `.gitattributes` | Configures binary detection and Git LFS tracking rules. | Added Codex-ready binary exclusions and LFS filters. |
+| `.gitignore` | Defines files and folders excluded from version control. | Removed lock files from ignore list to keep dependency tracking consistent. |
+| `.gitattributes` | Configures binary detection and Git LFS tracking rules. | Consolidated LFS rules to avoid conflicts and removed broad public wildcard. |
 | `.gitlfsconfig` | Repository-specific Git LFS configuration. | Documented default LFS settings for public assets. |
 | `.env.example` | Lists required environment variables with placeholders. | Documented required secrets for local setup. |
 | `CHANGELOG.md` | Records notable changes across releases. | Logged version 0.1.0 initial setup. |
@@ -15,4 +15,4 @@ Update this file whenever you add, remove, or significantly modify any file.
 | `docs/ARCHITECTURE.md` | Describes technical stack and architecture decisions. | Documented initial architecture. |
 | `docs/FILE_INVENTORY.md` | Tracks project files, their purposes, and changes. | Added Codex binary-prevention assets to inventory. |
 | `docs/SETUP.md` | Provides environment, tooling, and deployment instructions. | Documented setup steps for local and Vercel environments. |
-| `docs/CODEX_GUIDELINES.md` | Binary prevention and Git LFS guidance for AI contributors. | Created guidelines for Codex-safe asset handling. |
+| `docs/CODEX_GUIDELINES.md` | Binary prevention and Git LFS guidance for AI contributors. | Added verification checklist and critical Codex safeguards. |


### PR DESCRIPTION
## Summary
- add repository-wide .gitattributes rules for binary detection and Git LFS tracking
- configure Git LFS defaults and extend ignore patterns for build, OS, and upload artifacts
- document Codex binary workflows and record the additions in the file inventory and changelog

## Testing
- git check-attr -a public/favicon.ico
- git check-ignore .next/
- git lfs version
- git lfs track
- ls docs/CODEX_GUIDELINES.md

------
https://chatgpt.com/codex/tasks/task_e_68de6a1b116c8324ac137d43b27f53a7