### PR TITLE
docs: update env example for supabase defaults

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,11 +1,13 @@
-# Google service account email used for Sheets API access
-GOOGLE_CLIENT_EMAIL=your-service-account@example.iam.gserviceaccount.com
-
-# Google service account private key (wrap in quotes if it contains line breaks)
-GOOGLE_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----\nYOUR_KEY_HERE\n-----END PRIVATE KEY-----\n"
-
-# Google Sheet ID hosting StockFlow data
-GOOGLE_SHEET_ID=your-google-sheet-id
+# Supabase project configuration for StockFlow
+NEXT_PUBLIC_SUPABASE_URL=https://your-project-ref.supabase.co
+NEXT_PUBLIC_SUPABASE_ANON_KEY=your-supabase-anon-key
+SUPABASE_SERVICE_ROLE_KEY=your-supabase-service-role-key
 
 # OpenAI API key for categorization and validation features
 OPENAI_API_KEY=sk-your-openai-api-key
+
+# Optional: legacy Google Sheets export integration
+# Uncomment and configure only if you need to export data back to Google Sheets.
+# GOOGLE_CLIENT_EMAIL=your-service-account@example.iam.gserviceaccount.com
+# GOOGLE_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----\nYOUR_KEY_HERE\n-----END PRIVATE KEY-----\n"
+# GOOGLE_SHEET_ID=your-google-sheet-id

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 ### Changed
 - Expanded `.gitignore` entries to cover Next.js builds, OS files, and asset upload directories.
 - Consolidated `.gitattributes` LFS patterns and restored lock files to version control for reliable dependency auditing.
+- Updated `.env.example` to align with Supabase setup instructions while keeping Google Sheets export optional.
 
 ## [0.2.0] - 2025-10-02
 ### Changed

--- a/docs/FILE_INVENTORY.md
+++ b/docs/FILE_INVENTORY.md
@@ -9,7 +9,7 @@ Update this file whenever you add, remove, or significantly modify any file.
 | `.gitignore` | Defines files and folders excluded from version control. | Removed lock files from ignore list to keep dependency tracking consistent. |
 | `.gitattributes` | Configures binary detection and Git LFS tracking rules. | Consolidated LFS rules to avoid conflicts and removed broad public wildcard. |
 | `.gitlfsconfig` | Repository-specific Git LFS configuration. | Documented default LFS settings for public assets. |
-| `.env.example` | Lists required environment variables with placeholders. | Documented required secrets for local setup. |
+| `.env.example` | Lists required environment variables with placeholders. | Updated Supabase-focused defaults and marked Google Sheets export as optional. |
 | `CHANGELOG.md` | Records notable changes across releases. | Logged version 0.1.0 initial setup. |
 | `docs/CONTEXT.md` | Captures business context, rules, and decisions. | Documented initial business context. |
 | `docs/ARCHITECTURE.md` | Describes technical stack and architecture decisions. | Documented initial architecture. |


### PR DESCRIPTION
## Summary
- replace the Google Sheets variables in `.env.example` with Supabase placeholders and mark Sheets export as optional
- document the `.env.example` update in the file inventory and changelog

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68df206fa7048324b37b9d5760d732f2